### PR TITLE
show memory overlap

### DIFF
--- a/core/floor.go
+++ b/core/floor.go
@@ -30,13 +30,16 @@ func floorFactoryFull(name string, size int, teams []Team) Floor {
 func (floor Floor) WithTeam(team Team) Floor {
 
 	// ----
-	teams := make([]Team, len(floor.Teams)+2)
-	k := 0
-	for _, t := range floor.Teams {
-		teams[k] = t
-		k++
-	}
-	teams[k+1] = team
+	// teams := make([]Team, len(floor.Teams)+2)
+	// k := 0
+	// for _, t := range floor.Teams {
+	// 	teams[k] = t
+	// 	k++
+	// }
+	// teams[k+1] = team
+	//
+
+	teams := append(floor.Teams, team)
 	// ---> could have use append but some weird memory overlap happened
 	return floorFactoryFull(floor.Name, floor.Size, teams)
 }

--- a/main.go
+++ b/main.go
@@ -57,8 +57,8 @@ var (
 
 func main() {
 
-	teams := buildTeams2()
-	building := buildBuilding2()
+	teams := buildTeams()
+	building := buildBuilding()
 
 	if !building.IsBigEnoughForTeams(teams) {
 		fmt.Println("No enought space in floors to fit everyone !!")


### PR DESCRIPTION
PR non mergeable.
Met en evidence le problème de memoire que j'ai rencontré avec append.

Pour plus de lisibilité, chaque équipe est nommé avec sa taille:
  - A6 est une équipe de 6personnes
  - B14 est une équipe de 14 personnes
  - etc

Lorsqu'on run le script, on a une sortie incohérente sur la taille des équipes:

```nb
nb people 78
building capacity 123
7216
Building: 74 / 123:
1st floor (20/52):	A6 - B14 -
2nd floor (45/58):	C10 - D2 - E10 - F10 - G10 - J7 -
3rd floor (3/7):	H3 -
5th floor (6/6):	I6 -
-------------------------------------------------------
Building: 74 / 123:
1st floor (20/52):	A6 - B14 -
2nd floor (45/58):	C10 - D2 - E10 - F10 - G10 - J7 -
3rd floor (6/7):	I6 -
5th floor (3/6):	H3 -```

- Ici, l'etage 2 est affiché avec 45 personnes, alors que si on compte à la main, on devrait avoir 49 personnes.
- Le nbr de personnes dans un floor est recalculé a chaque création https://github.com/vianneyb/space_planning/compare/memory_bug?expand=1#diff-2cdb6e07c11f19c9359ba6290ebf6ebfR44

Ce que j'ai compris du problème, en jouant avec le debugger, c'est qu'à la création, le floor 2 est:
`2nd floor (45/58):	C10 - D2 - E10 - F10 - G10 - H3 -` ce qui fait bien 45 personnes.
A partir d'un certain nombres d'itérations, la référence vers H3 est remplacé par J7

